### PR TITLE
Specify node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "1.0.0",
   "description": "Takeoff RAG Course",
   "main": "index.js",
+  "engines": {
+    "node": ">=22.0.0 <23.0.0",
+    "npm": ">=10.9.0 <10.10.0"
+  },
   "scripts": {
     "db:generate:basics": "npx drizzle-kit generate --config=./sections/1-learn-the-basics/drizzle.config.ts",
     "db:migrate:basics": "npx drizzle-kit migrate --config=./sections/1-learn-the-basics/drizzle.config.ts"


### PR DESCRIPTION
With node23 I see below error. It works with `v22.14.0`

```
$ npx tsx ./1-setup.ts
...

SyntaxError: The requested module 'resolve-pkg-maps' does not provide an export named 'resolveExports'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:181:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:264:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:583:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:93:9)

Node.js v23.7.0
```